### PR TITLE
buildVars: change addon_description

### DIFF
--- a/buildVars.py
+++ b/buildVars.py
@@ -17,7 +17,7 @@ addon_info = {
 	"addon_summary" : _("Report Symbols"),
 	# Add-on description
 	# Translators: Long description to be shown for this add-on on add-on information from add-ons manager
-	"addon_description" : _("""Allows to listen the typed symbols (non alphanumeric characters), even when the speaking of characters is turned off."""),
+	"addon_description" : _("""Allows to listen the typed symbols (non alphanumeric characters or blank characters), even when the speaking of characters is turned off."""),
 	# version
 	"addon_version" : "3.0",
 	# Author(s)


### PR DESCRIPTION
### Link to issue number:
#2

### Summary of the issue:
Change the add-on description according with the documentation.

### Description of how this pull request fixes the issue:
This has been done modifying the value of the addon_info["addon_description"], in the buildVars.py file of the [add-on template](https://github.com/nvdaaddons/addontemplate)
