### PR TITLE
Compatibility with NVDA 2023.1

### DIFF
--- a/buildVars.py
+++ b/buildVars.py
@@ -29,7 +29,7 @@ addon_info = {
 	# Minimum NVDA version supported (e.g. "2018.3")
 	"addon_minimumNVDAVersion": "2019.3",
 	# Last NVDA version supported/tested (e.g. "2018.4", ideally more recent than minimum version)
-	"addon_lastTestedNVDAVersion": "2022.4",
+	"addon_lastTestedNVDAVersion": "2023.1",
 	# Add-on update channel (default is stable or None)
 	"addon_updateChannel": None,
 }

--- a/readme.md
+++ b/readme.md
@@ -12,6 +12,9 @@ It's based on the old ReportSymbols add-on, developed by the same author. You sh
 
 Note: A gesture to open this dialog can be assigned from NVDA menu, Preferences submenu, Input gestures dialog, Configuration category.
 
+## Changes for 8.0
+* Compatible with NVDA 2023.1.
+
 ## Changes for 7.0
 * Compatible with NVDA 2022.1.
 


### PR DESCRIPTION
## Link to issue number:
None
### Summary of the issue:
The add-on needs to be updated for compatibility with NVDA 2023.1.
### Description of how this pull request fixes the issue:
Updated last tested version and readme.
### Testing performed:
Code has been inspected.
### Known issues with pull request:
None
### Change log entry:
* Compatible with NVDA 2023.1.