### PR TITLE
Prepare for NVDA 2023.2

### DIFF
--- a/addon/globalPlugins/reportSymbols.py
+++ b/addon/globalPlugins/reportSymbols.py
@@ -99,7 +99,7 @@ class GlobalPlugin(globalPluginHandler.GlobalPlugin):
 				speech.speakSpelling(ch)
 
 	def onSettings(self, evt):
-		gui.mainFrame._popupSettingsDialog(NVDASettingsDialog, AddonSettingsPanel)
+		gui.mainFrame.popupSettingsDialog(NVDASettingsDialog, AddonSettingsPanel)
 
 	@script(
 		category=SCRCAT_CONFIG,

--- a/buildVars.py
+++ b/buildVars.py
@@ -27,9 +27,9 @@ addon_info = {
 	# Documentation file name
 	"addon_docFileName": "readme.html",
 	# Minimum NVDA version supported (e.g. "2018.3")
-	"addon_minimumNVDAVersion": "2019.3",
+	"addon_minimumNVDAVersion": "2023.2",
 	# Last NVDA version supported/tested (e.g. "2018.4", ideally more recent than minimum version)
-	"addon_lastTestedNVDAVersion": "2023.1",
+	"addon_lastTestedNVDAVersion": "2023.2",
 	# Add-on update channel (default is stable or None)
 	"addon_updateChannel": None,
 }


### PR DESCRIPTION
<!-- 
Based on pull request template of NVDA:
https://github.com/nvaccess/nvda/wiki/Github-pull-request-template-explanation-and-examples
-->
## Link to issue number:
None
### Summary of the issue:
popupSettingsDialog is public in NVDA 2023.2.
### Description of how this pull request fixes the issue:
Use the public function.
### Testing performed:
None yet.
### Known issues with pull request:
None.
### Change log entry:
* Requires NVDA 2023.2 or later.
