### PR TITLE
Fix deprecation import

### DIFF
--- a/addon/globalPlugins/reportSymbols.py
+++ b/addon/globalPlugins/reportSymbols.py
@@ -12,7 +12,8 @@ import api
 import config
 import speech
 import gui
-from gui import SettingsPanel, NVDASettingsDialog, guiHelper
+from gui import guiHelper
+from gui.settingsDialogs import SettingsPanel, NVDASettingsDialog
 from globalCommands import SCRCAT_CONFIG
 from scriptHandler import script
 


### PR DESCRIPTION
<!-- 
Based on pull request template of NVDA:
https://github.com/nvaccess/nvda/wiki/Github-pull-request-template-explanation-and-examples
-->
## Link to issue number:
None

Reported on the add-ons mailing list:

https://nvda-addons.groups.io/g/nvda-addons/message/23351

### Summary of the issue:
SettingsPanel shouldn't be imported from gui
### Description of how this pull request fixes the issue:
Import from gui.settingsDialogs
### Testing performed:
Tested locally.
### Known issues with pull request:
None
### Change log entry:
None